### PR TITLE
Check range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 *.ignore
 dest
 dist
+setup-tools/range_db
 .env

--- a/setup-tools/src/aztec_common/CMakeLists.txt
+++ b/setup-tools/src/aztec_common/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
     streaming_g2.cpp
     streaming_transcript.hpp
     streaming_transcript.cpp
+    streaming_range.hpp
     streaming.hpp
     streaming.cpp
 )
@@ -25,6 +26,7 @@ target_link_libraries(
     PUBLIC
         ${GMP_LIBRARIES}
         blake2
+        barretenberg
 )
 
 target_include_directories(
@@ -33,6 +35,7 @@ target_include_directories(
         ${DEPENDS_DIR}/blake2/ref
         ${DEPENDS_DIR}/libff
         ${GMP_INCLUDE_DIR}
+        ${DEPENDS_DIR}/barretenberg/src
 )
 
 install(

--- a/setup-tools/src/aztec_common/streaming_range.hpp
+++ b/setup-tools/src/aztec_common/streaming_range.hpp
@@ -1,0 +1,145 @@
+#pragma once
+#include "./streaming.hpp"
+#include "./streaming_g1.hpp"
+#include <barretenberg/fields/fr.hpp>
+#include <barretenberg/fields/fq.hpp>
+#include <barretenberg/groups/g1.hpp>
+
+#include "omp.h"
+
+constexpr size_t POINTS_PER_RANGE_FILE = 1000;
+constexpr size_t MAX_RANGE = 10000000;
+namespace streaming
+{
+namespace bb = barretenberg;
+
+bb::g1::affine_element decompress(const bb::fq::field_t& x_in)
+{
+    bb::fq::field_t uncompressed = x_in;
+    bool y_bit_flag = (uncompressed.data[3] >> 63ULL) == 1ULL;
+    // printf("y_bit_flag = %u \n", y_bit_flag ? 1 : 0);
+    uncompressed.data[3] = uncompressed.data[3] & 0x7fffffffffffffffULL;
+    bb::fq::field_t x;
+    bb::fq::to_montgomery_form(uncompressed, x);
+    bb::fq::field_t three{{ 3, 0, 0, 0}};
+    bb::fq::to_montgomery_form(three, three);
+    bb::fq::field_t yy;
+    bb::fq::__sqr(x, yy);
+    bb::fq::__mul(yy, x, yy);
+    bb::fq::__add(yy, three, yy);
+    bb::fq::field_t y;
+    bb::fq::__sqrt(yy, y);
+
+    bb::fq::field_t y_raw;
+    bb::fq::from_montgomery_form(y, y_raw);
+
+    bool is_odd = ((y_raw.data[0] & 1ULL) == 1ULL);
+    if (is_odd != y_bit_flag)
+    {
+        bb::fq::neg(y, y);
+    }
+    bb::g1::affine_element result;
+    result.x = x;
+    result.y = y;
+    return result;
+}
+
+bb::g1::affine_element read_bberg_element_from_buffer(char *buffer)
+{
+    bb::fq::field_t x;
+    bb::fq::field_t x_buf;
+
+
+    //  = &elements[i].X;
+    //  = &elements[i].Y;
+    memcpy(&x_buf, buffer, sizeof(bb::fq::field_t));
+
+    if (isLittleEndian())
+    {
+        x.data[3] = __bswap_64(x_buf.data[0]);
+        x.data[2] = __bswap_64(x_buf.data[1]);
+        x.data[1] = __bswap_64(x_buf.data[2]);
+        x.data[0] = __bswap_64(x_buf.data[3]);
+
+        // __bswap_bigint<num_limbs>(x);
+    }
+    else
+    {
+        x.data[3] = (x_buf.data[0]);
+        x.data[2] = (x_buf.data[1]);
+        x.data[1] = (x_buf.data[2]);
+        x.data[0] = (x_buf.data[3]);
+    }
+
+    bb::g1::affine_element element = decompress(x);
+    if (!bb::g1::on_curve(element) || bb::g1::is_point_at_infinity(element)) {
+        throw std::runtime_error("G1 points are not on the curve!");
+    }
+    return element;
+}
+
+void read_bberg_elements_to_file(bb::g1::affine_element* elements, char *buffer, size_t buffer_size, bool force_compression)
+{
+    const size_t bytes_per_element = sizeof(bb::fq::field_t);
+    size_t num_elements = buffer_size / bytes_per_element;
+    // elements.reserve(elements.size() + num_elements);
+    for (size_t i = 0; i < num_elements; ++i)
+    {
+        elements[i] = read_bberg_element_from_buffer(&buffer[i * bytes_per_element]);
+    }
+}
+
+void read_file(std::string range_path, std::vector<bb::g1::affine_element>& points)
+{
+    constexpr size_t num_files = (MAX_RANGE / POINTS_PER_RANGE_FILE) + 1;
+    const size_t num_threads = omp_get_max_threads();
+    const size_t files_per_thread = num_files / num_threads;
+    const size_t leftovers = num_files - (files_per_thread * num_threads);
+#pragma omp parallel for
+    for (size_t j = 0; j < num_threads; ++j)
+    {
+        size_t start = (j * files_per_thread);
+        size_t end = (j + 1) * files_per_thread;
+        if (j == num_threads - 1)
+        {
+            end += leftovers;
+        }
+        for (size_t i = start; i < end; ++i)
+        {
+            if ((i % 100) == 0)
+            {
+                printf("i = %lu \n", i);
+            }
+            size_t g1_buffer_size = 32 * POINTS_PER_RANGE_FILE;
+            if (i == num_files - 1)
+            {
+                g1_buffer_size = 32; // only 1 point here
+            }
+            std::string filename = range_path + "data" + std::to_string(i * POINTS_PER_RANGE_FILE) + ".dat";
+            //  std::cout << "filename = " << filename << std::endl;
+            auto buffer = read_file_into_buffer(filename);
+            read_bberg_elements_to_file(&points[i * POINTS_PER_RANGE_FILE], &buffer[0], g1_buffer_size, true);
+        }
+    }
+    // for (size_t i = 0; i < num_files; ++i)
+    // {
+    //     if (i % 100 == 0)
+    //     {
+    //         printf("i = %lu \n", i);
+    //     }
+    //     // printf("points size = %lu \n", points.size());
+    // }
+}
+}
+
+// 0x0118c4d5b837bcc2bc89b5b398b5974e9f5944073b32078b7e231fec938883b0
+// 0x0118c4d5b837bcc2bc89b5b398b5974e9f5944073b32078b7e231fec938883b0
+
+// 0x260e01b251f6f1c7e7ff4e580791dee8ea51d87a358e038b4efe30fac09383c1
+// 0x260e01b251f6f1c7e7ff4e580791dee8ea51d87a358e038b4efe30fac09383c1
+
+// 0x22febda3c0c0632a11e6dd3f96e6cea211e6dd3f96e6cea2854a87d4dacc5e55
+// 0x22febda3c0c0632a56475b4214e5615e11e6dd3f96e6cea2854a87d4dacc5e55
+
+// 0x04fc6369f7110fe3d25156c1bb9a72859cf2a04641f99ba4ee413c80da6a5fe4
+// 0x04fc6369f7110fe3d25156c1bb9a7285ee413c80da6a5fe4ee413c80da6a5fe4

--- a/setup-tools/src/aztec_common/streaming_range.hpp
+++ b/setup-tools/src/aztec_common/streaming_range.hpp
@@ -17,7 +17,7 @@ bb::g1::affine_element decompress(const bb::fq::field_t& x_in)
 {
     bb::fq::field_t uncompressed = x_in;
     bool y_bit_flag = (uncompressed.data[3] >> 63ULL) == 1ULL;
-    // printf("y_bit_flag = %u \n", y_bit_flag ? 1 : 0);
+
     uncompressed.data[3] = uncompressed.data[3] & 0x7fffffffffffffffULL;
     bb::fq::field_t x;
     bb::fq::to_montgomery_form(uncompressed, x);
@@ -50,8 +50,6 @@ bb::g1::affine_element read_bberg_element_from_buffer(char *buffer)
     bb::fq::field_t x_buf;
 
 
-    //  = &elements[i].X;
-    //  = &elements[i].Y;
     memcpy(&x_buf, buffer, sizeof(bb::fq::field_t));
 
     if (isLittleEndian())
@@ -60,8 +58,6 @@ bb::g1::affine_element read_bberg_element_from_buffer(char *buffer)
         x.data[2] = __bswap_64(x_buf.data[1]);
         x.data[1] = __bswap_64(x_buf.data[2]);
         x.data[0] = __bswap_64(x_buf.data[3]);
-
-        // __bswap_bigint<num_limbs>(x);
     }
     else
     {
@@ -82,7 +78,7 @@ void read_bberg_elements_to_file(bb::g1::affine_element* elements, char *buffer,
 {
     const size_t bytes_per_element = sizeof(bb::fq::field_t);
     size_t num_elements = buffer_size / bytes_per_element;
-    // elements.reserve(elements.size() + num_elements);
+
     for (size_t i = 0; i < num_elements; ++i)
     {
         elements[i] = read_bberg_element_from_buffer(&buffer[i * bytes_per_element]);
@@ -116,30 +112,10 @@ void read_file(std::string range_path, std::vector<bb::g1::affine_element>& poin
                 g1_buffer_size = 32; // only 1 point here
             }
             std::string filename = range_path + "data" + std::to_string(i * POINTS_PER_RANGE_FILE) + ".dat";
-            //  std::cout << "filename = " << filename << std::endl;
+
             auto buffer = read_file_into_buffer(filename);
             read_bberg_elements_to_file(&points[i * POINTS_PER_RANGE_FILE], &buffer[0], g1_buffer_size, true);
         }
     }
-    // for (size_t i = 0; i < num_files; ++i)
-    // {
-    //     if (i % 100 == 0)
-    //     {
-    //         printf("i = %lu \n", i);
-    //     }
-    //     // printf("points size = %lu \n", points.size());
-    // }
 }
 }
-
-// 0x0118c4d5b837bcc2bc89b5b398b5974e9f5944073b32078b7e231fec938883b0
-// 0x0118c4d5b837bcc2bc89b5b398b5974e9f5944073b32078b7e231fec938883b0
-
-// 0x260e01b251f6f1c7e7ff4e580791dee8ea51d87a358e038b4efe30fac09383c1
-// 0x260e01b251f6f1c7e7ff4e580791dee8ea51d87a358e038b4efe30fac09383c1
-
-// 0x22febda3c0c0632a11e6dd3f96e6cea211e6dd3f96e6cea2854a87d4dacc5e55
-// 0x22febda3c0c0632a56475b4214e5615e11e6dd3f96e6cea2854a87d4dacc5e55
-
-// 0x04fc6369f7110fe3d25156c1bb9a72859cf2a04641f99ba4ee413c80da6a5fe4
-// 0x04fc6369f7110fe3d25156c1bb9a7285ee413c80da6a5fe4ee413c80da6a5fe4

--- a/setup-tools/src/range_verify/CMakeLists.txt
+++ b/setup-tools/src/range_verify/CMakeLists.txt
@@ -1,0 +1,37 @@
+
+# trusted_setup_post_processing range
+# copyright spilsbury holdings 2019
+
+find_package (Threads)
+find_package (OpenMP)
+
+add_executable(
+    verify_range_points
+    main.cpp
+)
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(verify_range_points PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+target_link_libraries(
+    verify_range_points
+    PRIVATE
+        aztec_common
+        ff
+        ${CMAKE_THREAD_LIBS_INIT}
+        ${GMP_LIBRARIES}
+        barretenberg
+)
+
+target_include_directories(
+    verify_range_points
+    PRIVATE
+        ${DEPENDS_DIR}/libff
+        ${DEPENDS_DIR}/libfqfft
+        ${include_dir}
+        ${private_include_dir}
+        ${DEPENDS_DIR}/barretenberg/src
+)
+
+set_target_properties(verify_range_points PROPERTIES RUNTIME_OUTPUT_DIRECTORY ../..)

--- a/setup-tools/src/range_verify/main.cpp
+++ b/setup-tools/src/range_verify/main.cpp
@@ -1,0 +1,134 @@
+#include <iostream>
+#include <aztec_common/streaming_range.hpp>
+#include <barretenberg/fields/fr.hpp>
+#include <barretenberg/fields/fq.hpp>
+#include <barretenberg/groups/g1.hpp>
+#include <barretenberg/groups/g2.hpp>
+#include <barretenberg/fields/fq2.hpp>
+#include <barretenberg/fields/fq12.hpp>
+#include <barretenberg/groups/pairing.hpp>
+#include <barretenberg/groups/scalar_multiplication.hpp>
+
+namespace bb = barretenberg;
+
+inline uint32_t get_msb(uint32_t v)
+{
+    static const uint32_t MultiplyDeBruijnBitPosition[32] = { 0,  9,  1,  10, 13, 21, 2,  29, 11, 14, 16,
+                                                              18, 22, 25, 3,  30, 8,  12, 20, 28, 15, 17,
+                                                              24, 7,  19, 27, 23, 6,  26, 5,  4,  31 };
+
+    v |= v >> 1; // first round down to one less than a power of 2
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+
+    return MultiplyDeBruijnBitPosition[static_cast<uint32_t>(v * static_cast<uint32_t>(0x07C4ACDD)) >> static_cast<uint32_t>(27)];
+}
+
+bb::g2::affine_element t2;
+bb::g1::affine_element h;
+const auto init = [](){
+    t2.x.c0 = {{ 0x7e231fec938883b0, 0x9f5944073b32078b, 0xbc89b5b398b5974e, 0x0118c4d5b837bcc2 }};
+    t2.x.c1 = {{ 0x4efe30fac09383c1, 0xea51d87a358e038b, 0xe7ff4e580791dee8, 0x260e01b251f6f1c7 }};
+    t2.y.c0 = {{ 0x854a87d4dacc5e55, 0x11e6dd3f96e6cea2, 0x56475b4214e5615e, 0x22febda3c0c0632a }};
+    t2.y.c1 = {{ 0xee413c80da6a5fe4, 0x9cf2a04641f99ba4, 0xd25156c1bb9a7285, 0x04fc6369f7110fe3 }};
+
+    h.x = {{ 0x34c705638441c4b9, 0xf7473acbe61df671, 0x5d56d9653aed9dc7, 0x00164b60d0fa1eab }};
+    h.y = {{ 0xf0442fce79416cf0, 0x08611b4adeb4b838, 0x7254dfb9be2cb4e9, 0x2bb1b9b55ffdcf2d }};
+    bb::fq::to_montgomery_form(h.x, h.x);
+    bb::fq::to_montgomery_form(h.y, h.y);
+    bb::fq::to_montgomery_form(t2.x.c0, t2.x.c0);
+    bb::fq::to_montgomery_form(t2.x.c1, t2.x.c1);
+    bb::fq::to_montgomery_form(t2.y.c0, t2.y.c0);
+    bb::fq::to_montgomery_form(t2.y.c1, t2.y.c1);
+    return 1;
+}();
+
+
+/**
+ * verifies that all range proof points are valid
+ * 1st argument points to range proof database: "../range_db/"
+ * not included in the repo because it's 305MB large.
+ * Can be acquired from https://s3.console.aws.amazon.com/s3/buckets/aztec-ignition/MAIN%2520IGNITION/range_proofs/
+ **/ 
+int main(int argc, char **argv)
+{
+    const std::string generator_path = argv[1];
+    constexpr uint32_t NUM_POINTS = 10000001;
+    std::vector<bb::g1::affine_element> points;
+    points.resize(NUM_POINTS);
+    printf("reading points \n");
+    streaming::read_file(generator_path, points);
+
+
+    std::vector<bb::g1::element> right_points;
+    right_points.reserve(NUM_POINTS);
+    printf("accumulating g1 points \n");
+    for (uint32_t i = 0; i < static_cast<uint32_t>(points.size()); ++i)
+    {
+        uint32_t k = static_cast<uint32_t>(i);
+        bb::g1::element mu_k_plus_h;
+        bb::g1::set_infinity(mu_k_plus_h);
+        const uint32_t max_bits = get_msb(static_cast<uint32_t>(k)) + 1;
+        for (uint32_t j = max_bits; j <= max_bits; --j)
+        {
+            bb::g1::dbl(mu_k_plus_h, mu_k_plus_h);
+            if (((k >> j) & 1) == 1)
+            {
+                bb::g1::mixed_add(mu_k_plus_h, points[i], mu_k_plus_h);
+            }
+        }
+        bb::g1::mixed_add(mu_k_plus_h, h, mu_k_plus_h);
+        right_points.emplace_back(mu_k_plus_h);
+    }
+    bb::g1::batch_normalize(&right_points[0], NUM_POINTS);
+    std::vector<bb::g1::affine_element> right_points_affine;
+    right_points_affine.resize(NUM_POINTS);
+    for (size_t i = 0; i < NUM_POINTS; ++i)
+    {
+        right_points_affine[i].x = right_points[i].x;
+        right_points_affine[i].y = right_points[i].y;
+    }
+
+    bb::fr::field_t alpha = bb::fr::random_element();
+    bb::fr::field_t work_alpha = alpha;
+    std::vector<bb::fr::field_t> scalars_left;
+    std::vector<bb::fr::field_t> scalars_right;
+    scalars_left.reserve(NUM_POINTS);
+    scalars_right.reserve(NUM_POINTS);
+    printf("generating scalars \n");
+    for (size_t i = 0; i < NUM_POINTS; ++i)
+    {
+        scalars_left.push_back(work_alpha);
+        scalars_right.push_back(work_alpha);
+        bb::fr::__mul(work_alpha, alpha, work_alpha);
+    }
+    printf("performing multiexp\n");
+    bb::g1::element lhs = bb::scalar_multiplication::pippenger_low_memory(&scalars_left[0], &points[0], NUM_POINTS);
+    bb::g1::element rhs = bb::scalar_multiplication::pippenger_low_memory(&scalars_right[0], &right_points_affine[0], NUM_POINTS);
+    printf("evaluating pairing \n");
+    bb::g1::affine_element left;
+    bb::g1::affine_element right;
+    bb::g1::jacobian_to_affine(lhs, left);
+    bb::g1::jacobian_to_affine(rhs, right);
+
+    bb::g1::affine_element P[2];
+    bb::g2::affine_element Q[2];
+    P[0] = left;
+    P[1] = right;
+    Q[0] = t2;
+    Q[1] = bb::g2::affine_one();
+    bb::g1::neg(P[0], P[0]);
+    bb::fq12::fq12_t out = bb::pairing::reduced_ate_pairing_batch(P, Q, 2);
+    bool result = bb::fq12::eq(out, bb::fq12::one());
+
+    if (!result)
+    {
+        throw std::runtime_error("pairing check failed!");
+    }
+    else
+    {
+        printf("range points valid! \n");
+    }
+}


### PR DESCRIPTION
Added `verify_range` executable, that will validate the correctness of the group elements generated to construct AZTEC range proofs.  

It correctly validates that these points are valid, and correctly map to the integers 0 to 10,000,000