### PR TITLE
Set timezone as ENV var in docker

### DIFF
--- a/setup-tools/Dockerfile.build
+++ b/setup-tools/Dockerfile.build
@@ -1,4 +1,6 @@
 FROM ubuntu:latest
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && apt-get install -y build-essential wget libgmp3-dev pkg-config libssl-dev
 RUN wget https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz \
   && tar zxfv cmake-3.15.4.tar.gz \


### PR DESCRIPTION
### Issue

Running `./build_client.sh` on top of current master gets stuck here:
```
Setting up libassuan0:amd64 (2.5.3-7ubuntu2) ...
Setting up libgomp1:amd64 (10-20200411-0ubuntu1) ...
Setting up libldap-common (2.4.49+dfsg-2ubuntu1.2) ...
Setting up libfakeroot:amd64 (1.24-1) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg-2) ...
Setting up tzdata (2020a-0ubuntu0.20.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:

```

This is waiting for user input because the timezone isn't configured.

### Fix

I've added two lines to `setup-tools/Dockerfile.build`:

```Dockerfile
ENV TZ=Europe/Berlin
RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
```

This way there's a default timezone and it can be configured via build args.

