### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you want to get ambitious, you may wish to run the computation on, for exampl
 Further, you may wish to run either your own implementation, or build the `setup-tools` binaries and run those.
 
 Either way, it's still necessary to signal to the server that you are online, in order to be allocated your position in the queue. This can be achieved by running `setup-mpc-client` in a special offline mode,
-or you can use something like the `simulate_client.sh` script in `setup-mpc-client-bash` to acheive the same without running the container, sacrificing visualisation of the ceremony.
+or you can use something like the `simulate_client.sh` script in `setup-mpc-client-bash` to achieve the same without running the container, sacrificing visualisation of the ceremony.
 
 The instructions in [setup-tools](/setup-tools) should guide you on how to build and run the binaries.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to ensure you are meeting the targeted verification rate throughout the process.
 If you want to get ambitious, you may wish to run the computation on, for example, an air-gapped laptop within a faraday cage in the middle of a desert.
 Further, you may wish to run either your own implementation, or build the `setup-tools` binaries and run those.
 
-Either way, it's still necessary to signal to the server that you are online, in order to be allocated your position in the queue. This can be acheived by running `setup-mpc-client` in a special offline mode,
+Either way, it's still necessary to signal to the server that you are online, in order to be allocated your position in the queue. This can be achieved by running `setup-mpc-client` in a special offline mode,
 or you can use something like the `simulate_client.sh` script in `setup-mpc-client-bash` to acheive the same without running the container, sacrificing visualisation of the ceremony.
 
 The instructions in [setup-tools](/setup-tools) should guide you on how to build and run the binaries.

--- a/setup-mpc-client/README.md
+++ b/setup-mpc-client/README.md
@@ -9,9 +9,9 @@ Participants in the AZTEC trusted setup multi party computation fall into three 
 
 1. **Institutional participants** - These participants are known up front and have been formally accepted into the computation by AZTEC. They have top priority during the ceremony.
 2. **Early bird individuals** - Participants that have signed up for the ceremony prior to the _selection date_. They have secondary priority during the ceremony.
-3. **Individuals** - Participants that have signed up for the ceremony after the _selection date_, or who were not choosen during selection. They have tertiary priority during the ceremony.
+3. **Individuals** - Participants that have signed up for the ceremony after the _selection date_, or who were not chosen during selection. They have tertiary priority during the ceremony.
 
-The _selection date_ is goverened by a predetermined Ethereum block height. The block hash of the block is used as a seed to a pseudo random number generator which first selects a number of participants from tier 2, and is then used to randomise the priority order of participants in both tier 1 and tier 2. Unselected participants and participants in tier 3 are ordered on a first come first served basis.
+The _selection date_ is governed by a predetermined Ethereum block height. The block hash of the block is used as a seed to a pseudo random number generator which first selects a number of participants from tier 2, and is then used to randomise the priority order of participants in both tier 1 and tier 2. Unselected participants and participants in tier 3 are ordered on a first come first served basis.
 
 To sign up for participation, a user must send 1 wei to the AZTEC controlled address `0x000000000xxxxxxx0000000`. The private key of the sending address must be provided to the client application for authentication.
 

--- a/setup-tools/README.md
+++ b/setup-tools/README.md
@@ -143,7 +143,7 @@ Ensure that at the top level of the repo you have run:
 git submodule init && git submodule update
 ```
 
-To ease development you can create an image with necessary build environment, with your current source code mounted into the conatiner.
+To ease development you can create an image with necessary build environment, with your current source code mounted into the container.
 
 ```
 docker-compose build build-env


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "acheived" to "achieved".
Corrected "acheive" to "achieve".
Corrected "choosen" to "chosen".
Corrected "goverened" to "governed".
Corrected "conatiner" to "container".

Please review the changes and let me know if any additional changes are needed.

